### PR TITLE
Fix/center icons

### DIFF
--- a/src/features/all-pages/ui/atoms/icon.tsx
+++ b/src/features/all-pages/ui/atoms/icon.tsx
@@ -21,8 +21,9 @@ const IconWrapper = styled.div<{ backgroud: ColorType; size: number; borderRadiu
 
     svg {
         color: #fff;
-        width: ${({ size }) => size / 2 + 'px'};
-        height: ${({ size }) => size / 2 + 'px'};
+        width: 100%;
+        height: 100%;
+        scale: 0.5;
     }
 `
 


### PR DESCRIPTION
width: 50%;
height: 50%; 
выдают некорректное отображение. я хз

поэтому использую scale: 0.5, с ним все гуд