### PR TITLE
Fix/prevent default behaviour

### DIFF
--- a/src/shared/lib/hooks/use-short-cut-keys.ts
+++ b/src/shared/lib/hooks/use-short-cut-keys.ts
@@ -10,6 +10,7 @@ const useShortCutKeys = (keys: string[], onPressed: () => void) => {
             const sliced = keys.slice(0, keys.length - 1)
 
             if (!sliced.find((k) => !keys_pressed.has(k)) && keys[keys.length - 1] === event.key) {
+                event.preventDefault()
                 onPressed()
             }
         })


### PR DESCRIPTION
На винде Ctrl + K вызывала стандартную хромовскую функцию поиска вместо поиска по ЛК