### PR TITLE
Fix/event info

### DIFF
--- a/src/features/schedule/ui/subject/modal/index.tsx
+++ b/src/features/schedule/ui/subject/modal/index.tsx
@@ -26,7 +26,6 @@ import calcTimeLeft from '@shared/lib/dates/calc-time-left'
 const SubjectModalWrapper = styled.div`
     position: relative;
     height: 100%;
-    max-width: 400px;
 
     @media (min-width: 1001px) {
         min-width: 320px;

--- a/src/shared/ui/calendar/calendars/day/styles.ts
+++ b/src/shared/ui/calendar/calendars/day/styles.ts
@@ -23,7 +23,8 @@ export const EventInfo = styled.div`
     background: var(--block-content);
     border-radius: 10px;
     top: 0;
-    overflow: hidden;
+    overflow-y: auto;
+    overflow-x: hidden;
     box-shadow: var(--block-shadow);
 
     ${MEDIA_QUERIES.isSmallTesktop} {

--- a/src/shared/ui/calendar/calendars/day/ui/styles.ts
+++ b/src/shared/ui/calendar/calendars/day/ui/styles.ts
@@ -13,7 +13,7 @@ export const EventBackgroundStyled = styled.div<{ background: string; noPadding:
     z-index: -1;
     overflow: hidden;
 
-    ${MEDIA_QUERIES.isMobile} {
+    @media (max-width: 800px) {
         width: calc(100% + 40px);
     }
 `


### PR DESCRIPTION
Была проблема в отсутствии скрола на окне c информацией о занятии при большом количестве преподавателей и не только. 
![telegram-cloud-photo-size-2-5359598979425361837-y](https://github.com/skaele/LK/assets/74768367/64aea497-095b-490d-9eac-88b5f1c24f9d)
был добавлен скролл: 
![telegram-cloud-photo-size-2-5359598979425361865-y](https://github.com/skaele/LK/assets/74768367/2fadfed4-9775-4617-9ddb-b73e0ed4c2ad)

А так же исправлена проблема с обрезанным контентом в модальном окне при ширине экрана меньше 800 пикселей: 
![telegram-cloud-photo-size-2-5377700771929382594-y](https://github.com/skaele/LK/assets/74768367/3e2e4c84-f38f-42c4-818e-655b3020c7d7)
Убрано обрезание контента и исправлен горизонтальный скролл от 766-800px : 
<img width="807" alt="image" src="https://github.com/skaele/LK/assets/74768367/3b1c33bc-417a-431e-a575-918779e1edcc">


