### PR TITLE
fix: menu route matching

### DIFF
--- a/src/widgets/leftside-bar/ui/organisms/leftside-bar-list.tsx
+++ b/src/widgets/leftside-bar/ui/organisms/leftside-bar-list.tsx
@@ -92,7 +92,9 @@ const LeftsideBarList = () => {
                         <LeftsideBarItem
                             {...props}
                             key={props?.id}
-                            isCurrent={location.pathname.includes(props.path)}
+                            isCurrent={
+                                location.pathname === props.path || location.pathname.startsWith(`${props.path}/`)
+                            }
                         />
                     )
                 })}

--- a/src/widgets/leftside-bar/ui/organisms/leftside-bar-list.tsx
+++ b/src/widgets/leftside-bar/ui/organisms/leftside-bar-list.tsx
@@ -88,14 +88,10 @@ const LeftsideBarList = () => {
             {Object.values(leftsideBarRoutes)
                 .filter(Boolean)
                 .map((props: IRoute) => {
+                    const escapedRoute = props.path.replace(/[^\w]/g, '\\$&')
+                    const routePattern = new RegExp(`^${escapedRoute}([\\/\\?#].*)?$`)
                     return (
-                        <LeftsideBarItem
-                            {...props}
-                            key={props?.id}
-                            isCurrent={
-                                location.pathname === props.path || location.pathname.startsWith(`${props.path}/`)
-                            }
-                        />
+                        <LeftsideBarItem {...props} key={props?.id} isCurrent={routePattern.test(location.pathname)} />
                     )
                 })}
         </LeftsideBarListWrapper>


### PR DESCRIPTION
before: 
<img width="211" alt="image" src="https://github.com/skaele/LK/assets/31708294/9b8cb5a4-9f2f-4c73-9017-7842a4b3c304">
(`/all-students` includes `/all`)

after: 
<img width="211" alt="image" src="https://github.com/skaele/LK/assets/31708294/1f4e1fdd-b468-47a6-80fd-8a88e5b1a429">

accounts for:
- complete match (will match `/foo` on `/foo`)
- nested routes (will match `/foo` on `/foo/bar`)
- search query (will match `/foo` on `/foo?bar=baz`)
- anchor hash (will match `/foo` on `/foo#bar`)